### PR TITLE
Add css for styling module list

### DIFF
--- a/frontend-react/src/components/ModuleList.tsx
+++ b/frontend-react/src/components/ModuleList.tsx
@@ -5,7 +5,13 @@ import { ModuleMenuResponse } from "../api";
 type ModuleListProps = { listData: ModuleMenuResponse };
 export function ModuleList({ listData }: ModuleListProps) {
   return (
-    <List>
+    <List
+      sx={{
+        "& > :nth-child(2n):not(:hover)": {
+          background: "#f1f1f1",
+        },
+      }}
+    >
       {listData.entries.type === "Submenu" &&
         listData.entries.value.map((e) => (
           <RouterLink


### PR DESCRIPTION
This PR adds a small styling prop value to the module list. It now alternates background colors:
![image](https://user-images.githubusercontent.com/78490564/193476910-d0c90f03-adaf-433b-af67-2994b9e2b28b.png)


* Closes #35 