### PR TITLE
Add color coding for initial fetch button

### DIFF
--- a/frontend-react/src/routes/InitialFetch.tsx
+++ b/frontend-react/src/routes/InitialFetch.tsx
@@ -9,6 +9,21 @@ import { useState } from "react";
 export default function InitialFetch() {
   const [data, setData] = useState<string>("");
   const [loading, setLoading] = useState(false);
+  const [buttonVariant, setButtonVariant] = useState("primary");
+  const setSuccess = (success: boolean | null) => {
+    switch (success) {
+      default:
+      case null:
+        setButtonVariant("primary");
+        break;
+      case false:
+        setButtonVariant("warning");
+        break;
+      case true:
+        setButtonVariant("success");
+        break;
+    }
+  };
   const [error, setError] = useState<string | null>(null);
 
   return (
@@ -16,8 +31,10 @@ export default function InitialFetch() {
       {error && <Alert severity="error">{error}</Alert>}
       <LoadingButton
         loading={loading}
+        color={buttonVariant}
         onClick={() => {
           (async () => {
+            setSuccess(null);
             setError(null);
             setLoading(true);
 
@@ -36,12 +53,16 @@ export default function InitialFetch() {
             while (!(value = await reader?.read())?.done) {
               setData(new TextDecoder().decode(value?.value));
             }
+            setData("Fertig");
+            setSuccess(true);
           })()
             .catch((error) => {
               setError(String(error));
+              setSuccess(false);
             })
             .finally(() => {
               setLoading(false);
+              setSuccess(true);
             });
         }}
       >

--- a/frontend-react/src/routes/InitialFetch.tsx
+++ b/frontend-react/src/routes/InitialFetch.tsx
@@ -6,10 +6,12 @@ import LoadingButton from "@mui/lab/LoadingButton";
 import Alert from "@mui/material/Alert";
 import { useState } from "react";
 
+type buttonVariantType = "primary" | "warning" | "success" | undefined;
 export default function InitialFetch() {
   const [data, setData] = useState<string>("");
   const [loading, setLoading] = useState(false);
-  const [buttonVariant, setButtonVariant] = useState("primary");
+  const [buttonVariant, setButtonVariant] =
+    useState<buttonVariantType>("primary");
   const setSuccess = (success: boolean | null) => {
     switch (success) {
       default:


### PR DESCRIPTION
This removes the last module entry on success (or rather replaces it with "Fertig") and styles the button accordingly:
![image](https://user-images.githubusercontent.com/78490564/193477852-7ca9e1fc-c9d5-4961-b6f0-f375560e8b8c.png)


* Closes #34